### PR TITLE
Fix require order (thank @spaceghost for finding this)

### DIFF
--- a/lib/decorators.rb
+++ b/lib/decorators.rb
@@ -1,6 +1,5 @@
 module Decorators
   require 'decorators/paths'
-  require 'decorators/railtie'
 
   class << self
     def load!(cache_classes)
@@ -32,3 +31,5 @@ module Decorators
   end
 
 end
+
+require 'decorators/railtie'


### PR DESCRIPTION
This was the cause of https://github.com/NJayDevelopment/mongoid_forums/issues/16

@spaceghost actually found it and told me how to fix it, here is the patch. It simply moves where you require ```decorators/railtie```.