### PR TITLE
Update to support Rails 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 rvm:
   - 2.5.1

--- a/decorators.gemspec
+++ b/decorators.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.name              = %q{decorators}
-  s.version           = %q{2.0.4}
+  s.version           = %q{2.0.5}
   s.description       = %q{Manages the process of loading decorators into your Rails application.}
   s.summary           = %q{Rails decorators plugin.}
   s.email             = %q{gems@p.arndt.io}

--- a/decorators.gemspec
+++ b/decorators.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     readme.md
   ]
 
-  s.add_dependency             "railties", ">= 4.0.0", "< 6"
+  s.add_dependency             "railties", ">= 4.0.0", "< 7"
   s.add_development_dependency "rspec", "~> 3.5", ">= 3.5.0"
 
   s.cert_chain  = ["certs/parndt.pem"]


### PR DESCRIPTION
This gem is a transitive dependency of RefineryCMS. We need to update this restriction in order to have RefineryCMS support Rails 6.